### PR TITLE
Update status on Language::Bel

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,10 @@ Listed primarily by the language which can be used for interoperability / [FFI](
 
 ## Misc
 
-- [Bel](http://paulgraham.com/bel.html) - self-hosted lisp dialect, currently no implementation exists, see also markdown formatted [mirror](https://github.com/alephyud/bel)
-  - [Babybel](https://github.com/cookrn/babybel) - Ruby implementation of Bel
-  - [Chime](https://github.com/jeremyschlatter/chime/) - hobby implementation of Bel written in Haskell
+- [Bel](http://paulgraham.com/bel.html) - self-hosted lisp dialect, see also markdown formatted [mirror](https://github.com/alephyud/bel)
   - [Language::Bel](https://github.com/masak/bel) - implementation of Bel in Perl 5, includes extensive test suite
+  - [Chime](https://github.com/jeremyschlatter/chime/) - hobby implementation of Bel written in Haskell
+  - [Babybel](https://github.com/cookrn/babybel) - Ruby implementation of Bel
 - [Loko Scheme](https://gitlab.com/weinholt/loko) [Type-S] runs on bare hardware
 - [uLisp](http://www.ulisp.com/) - Lisp for microcontrollers, fits into 2 Kbytes of RAM
 - A list of more [Clojure-like languages](https://github.com/chr15m/awesome-clojure-likes).


### PR DESCRIPTION
Bel is presented as currently having no implementation, but both Language::Bel and Chime are fairly feature-complete ones.
(Both a bit slow, but that's another matter.)
This commit orders the implementations in decreasing order of feature-completeness.