### PR TITLE
Fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If we translate the languages to a common syntax the similarities are more appar
 *In addition to translating the syntax some additional features/semantics that are not present in the target language are added. Usually if a language does not fit in other category, it can be considered being a Type-B.*
 
 - **Type-C**: [Clojure](https://clojure.org/)-like  
-*Distintive syntax that besides parentheses also uses brackets and curly braces. Distinctive features are persistent data structures, namespaces and vars, protocols.*
+*Distinctive syntax that besides parentheses also uses brackets and curly braces. Distinctive features are persistent data structures, namespaces and vars, protocols.*
 
 - **Type-L**: [Common Lisp](https://en.wikipedia.org/wiki/Common_Lisp)  
 *Implementing ANSI Common Lisp standard or being inspired by it.*


### PR DESCRIPTION
It seems the word "Distintive" should be "Distinctive".